### PR TITLE
Fix statusBarStack is undefined

### DIFF
--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -21,7 +21,7 @@ function StatusBar() {
   }
 
   function lastBarStyle(statusBarStack) {
-    return statusBarStack[statusBarStack.length - 1];
+    return statusBarStack && statusBarStack[statusBarStack.length - 1];
   }
 
   function currentBarStyle() {


### PR DESCRIPTION
fixes #12. Error occurs when navigation using a SwitchNavigator or AnimatedSwitchNavigator