### PR TITLE
Fix state updates on unmounted components

### DIFF
--- a/src/EventHandler.js
+++ b/src/EventHandler.js
@@ -2,18 +2,13 @@
 import type { EventHandlerType } from './types';
 
 function EventHandler<T>(): EventHandlerType<T> {
-  const listeners = [];
+  let listeners = [];
   function listen(listener: T => void) {
     listeners.push(listener);
   }
 
   function removeListener(listener: T => void) {
-    for (let i = 0; i < listeners.length; i++) {
-      if (listeners[i] === listener) {
-        listeners.splice(i, 1)
-        break;
-      }
-    }
+    listeners = listeners.filter(element => element !== listener)
   }
 
   function fire(value: T) {

--- a/src/EventHandler.js
+++ b/src/EventHandler.js
@@ -7,13 +7,22 @@ function EventHandler<T>(): EventHandlerType<T> {
     listeners.push(listener);
   }
 
+  function removeListener(listener: T => void) {
+    for (let i = 0; i < listeners.length; i++) {
+      if (listeners[i] === listener) {
+        listeners.splice(i, 1)
+        break;
+      }
+    }
+  }
+
   function fire(value: T) {
     listeners.forEach((listener: T => void) => {
       listener(value);
     });
   }
 
-  return { listen, fire };
+  return { listen, removeListener, fire };
 }
 
 export default EventHandler;

--- a/src/api/Container.js
+++ b/src/api/Container.js
@@ -85,7 +85,7 @@ class Container extends React.Component<ContainerProps, ContainerState> {
       y + 1 >= transitionPoint - navigationBarHeight
     ) {
       this.setState({ reachedTransitionPoint: true }, () => {
-        this.eventHandler.fire(this.state);
+        typeof this.eventHandler === "function" && this.eventHandler.fire(this.state);
       });
       if (afterTransitionPoint !== undefined) afterTransitionPoint();
     }
@@ -94,7 +94,7 @@ class Container extends React.Component<ContainerProps, ContainerState> {
       y + 1 < transitionPoint - navigationBarHeight
     ) {
       this.setState({ reachedTransitionPoint: false }, () => {
-        this.eventHandler.fire(this.state);
+        typeof this.eventHandler === "function" && this.eventHandler.fire(this.state);
       });
       if (beforeTransitionPoint !== undefined) beforeTransitionPoint();
     }

--- a/src/api/Header/HeaderBorder.js
+++ b/src/api/Header/HeaderBorder.js
@@ -12,15 +12,19 @@ class HeaderBorder extends React.Component<HeaderBorderProps> {
 
   componentDidMount() {
     const { containerEvents } = this.props;
-    this.listener = ({ reachedTransitionPoint }) => {
-        this.setState({ reachedTransitionPoint });
-    };
-    containerEvents.listen(this.listener);
+    if(containerEvents){
+      this.listener = ({ reachedTransitionPoint }) => {
+          this.setState({ reachedTransitionPoint });
+      };
+      containerEvents.listen(this.listener);
+    }
   }
 
   componentWillUnmount() {
     const { containerEvents } = this.props;
-    containerEvents.removeListener(this.listener);
+    if(containerEvents){
+      containerEvents.removeListener(this.listener);
+    }
   }
 
   render() {

--- a/src/api/Header/HeaderBorder.js
+++ b/src/api/Header/HeaderBorder.js
@@ -12,9 +12,15 @@ class HeaderBorder extends React.Component<HeaderBorderProps> {
 
   componentDidMount() {
     const { containerEvents } = this.props;
-    containerEvents.listen(({ reachedTransitionPoint }) => {
-      this.setState({ reachedTransitionPoint });
-    });
+    this.listener = ({ reachedTransitionPoint }) => {
+        this.setState({ reachedTransitionPoint });
+    };
+    containerEvents.listen(this.listener);
+  }
+
+  componentWillUnmount() {
+    const { containerEvents } = this.props;
+    containerEvents.removeListener(this.listener);
   }
 
   render() {

--- a/src/api/Header/HeaderNavigationBar.js
+++ b/src/api/Header/HeaderNavigationBar.js
@@ -29,14 +29,14 @@ class HeaderNavigationBar extends React.Component<
     const { containerEvents } = this.props;
     if (containerEvents !== undefined){
         this.listener = containerState => this.setState(containerState);
-        containerEvents.listen();
+        containerEvents.listen(this.listener);
     }
   }
 
   componentWillUnmount() {
     const { containerEvents } = this.props;
     if (containerEvents !== undefined){
-      containerEvents.listen(this.listener);
+      containerEvents.removeListener(this.listener);
     }
   }
 

--- a/src/api/Header/HeaderNavigationBar.js
+++ b/src/api/Header/HeaderNavigationBar.js
@@ -27,8 +27,17 @@ class HeaderNavigationBar extends React.Component<
 
   componentDidMount() {
     const { containerEvents } = this.props;
-    if (containerEvents !== undefined)
-      containerEvents.listen(containerState => this.setState(containerState));
+    if (containerEvents !== undefined){
+        this.listener = containerState => this.setState(containerState);
+        containerEvents.listen();
+    }
+  }
+
+  componentWillUnmount() {
+    const { containerEvents } = this.props;
+    if (containerEvents !== undefined){
+      containerEvents.listen(this.listener);
+    }
   }
 
   render() {

--- a/src/api/Header/HeaderNavigationBar.js
+++ b/src/api/Header/HeaderNavigationBar.js
@@ -27,7 +27,7 @@ class HeaderNavigationBar extends React.Component<
 
   componentDidMount() {
     const { containerEvents } = this.props;
-    if (containerEvents !== undefined){
+    if (containerEvents){
         this.listener = containerState => this.setState(containerState);
         containerEvents.listen(this.listener);
     }
@@ -35,7 +35,7 @@ class HeaderNavigationBar extends React.Component<
 
   componentWillUnmount() {
     const { containerEvents } = this.props;
-    if (containerEvents !== undefined){
+    if (containerEvents){
       containerEvents.removeListener(this.listener);
     }
   }

--- a/src/types.js
+++ b/src/types.js
@@ -37,6 +37,7 @@ export type ContainerState = {
 
 export type EventHandlerType<T: mixed> = {
   listen: ((T) => void) => void,
+  removeListener: ((T) => void) => void,
   fire: T => void
 };
 


### PR DESCRIPTION
Fixes #11 

@zobeirhamid  So, HeaderNavigationBar and HeaderBorder register listeners on `componentDidMount` while in my case (after testing), componentWillUnmount triggers immediately. So the component gets created and destroyed instantly, but keeps adding listeners, which still call `fire()`.

This is a a memory leak, as the listener array grows and grows but also throws warnings since the component is already unmounted. Memory usage of my app shrinked after my adjustments.

I added types and a `removeListener` function and some extra checks. On componentWillUnmount, I remove the listener. Since they've been passed as anonymous function, I stored it to `this.listener` and use them for listening and removing.

I just tested this for my case, using following code:

```jsx
                <ScrollableNavigationBar
                    transitionPoint={180}
                    title="Profil"
                    StatusBar={() => (
                        <StatusBarComponent
                            barStyle="light-content"
                            backgroundColor="transparent"
                        />
                    )}
                    titleStyle={{color: 'white'}}
                    headerBackgroundColor="#b7cc23"
                    headerTitle={"Profil"}
                    showsVerticalScrollIndicator={true}
                    barStyle="light-content"
                    scrollIndicatorInsets={{
                        top: 135,
                        left: 0,
                        bottom: 0,
                        right: 0
                    }}
                    snapToInterval={84}
                    snapToAlignment={"start"}
                >
```

No side effects, no issues. It also looks like, that components get mounted/unmounted on scroll, so this handling should be fine now.

I would kindly ask you to review and test this on your branch, maybe against your demos and merge this + create a new release anytime soon. Thanks!
 