### PR TITLE
Support iPhone 15 Pro Max, 15 Plus, 14 Pro Max

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,9 @@ function isIphoneX() {
       dimen.height === 896 ||
       dimen.width === 896 ||
       dimen.height === 926 ||
-      dimen.width === 926)
+      dimen.width === 926 ||
+      dimen.height === 932 ||
+      dimen.width === 932)
   );
 }
 


### PR DESCRIPTION
Hello,

Having an iPhone 15 Pro Max, the screen height is 932. 

Best regards,

Kevin

https://useyourloaf.com/blog/iphone-15-screen-sizes/#the-complete-list-of-iphones-and-an-ipod